### PR TITLE
Clear tempBuffer after file processing to ensure the array is no long…

### DIFF
--- a/src/server/controllers/item/create-item-controller.ts
+++ b/src/server/controllers/item/create-item-controller.ts
@@ -158,6 +158,7 @@ export const createItemController = (req: IGetUserAuthInfoRequest, res: Response
                         removeUploadedFile(kpiFilename)
                         // eslint-disable-next-line max-len
                         logger.info(`Parsed ${rowCount} records in ${(Date.now() - parsingStart) / SECONDS_DIVISOR} seconds`)
+                        tempBuffer = null
                         await itemDataProcessing({
                             itemId,
                             projectName, scenarioName,
@@ -170,6 +171,7 @@ export const createItemController = (req: IGetUserAuthInfoRequest, res: Response
                 })
                 .on("error", async (processingError) => {
                     logger.info(`File processing was aborted because of an error, item_id: ${itemId}`)
+                    tempBuffer = null
                     await handleError(itemId, kpiFilename, processingError)
                 })
         } catch(e) {


### PR DESCRIPTION
Clear tempBuffer after file processing to ensure the array is no longer referenced and can be gc'ed.

https://github.com/ludeknovy/jtl-reporter/issues/259