### PR TITLE
Add timestamp to log

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,10 @@
 import * as winston from "winston"
 
 export const logger = winston.createLogger({
+  format: winston.format.combine(
+    winston.format.timestamp({ format: "YYYY-MM-DD hh:mm:ss A" }),
+    winston.format.json()
+  ),
   levels: winston.config.syslog.levels,
   transports: [ new winston.transports.Console() ],
 })

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import * as winston from "winston"
 
 export const logger = winston.createLogger({
   format: winston.format.combine(
-    winston.format.timestamp({ format: "YYYY-MM-DD hh:mm:ss A" }),
+    winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
     winston.format.json()
   ),
   levels: winston.config.syslog.levels,


### PR DESCRIPTION
Hi, @ludeknovy !
I noticed that be-service logs are not time stamped and are very difficult to read in the console when analyzing different situations. I suggest adding timestamp and making a small change in logging