### PR TITLE
feat(items): add batch delete endpoint for multiple test run items

### DIFF
--- a/src/server/controllers/item/delete-items-controller.ts
+++ b/src/server/controllers/item/delete-items-controller.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from "express"
+import { db } from "../../../db/db"
+import { deleteItems } from "../../queries/items"
+import { logger } from "../../../logger"
+import { StatusCode } from "../../utils/status-code"
+
+export const deleteItemsController = async (req: Request, res: Response) => {
+  const { projectName, scenarioName } = req.params
+  const { itemIds } = req.body
+
+  await db.any(deleteItems(projectName, scenarioName, itemIds))
+
+  logger.info(`Items ${itemIds.join(", ")} deleted.`)
+  res.status(StatusCode.NoContent).send()
+}

--- a/src/server/queries/items.ts
+++ b/src/server/queries/items.ts
@@ -107,6 +107,17 @@ export const deleteItem = (projectName, scenarioName, itemId) => {
     }
 }
 
+export const deleteItems = (projectName: string, scenarioName: string, itemIds: string[]) => ({
+    text: `DELETE FROM jtl.items
+    WHERE id = ANY($1::uuid[])
+    AND scenario_id = (
+      SELECT s.id FROM jtl.scenario as s
+      JOIN jtl.projects as p ON p.id = s.project_id
+      WHERE s.name = $2 AND p.project_name = $3
+    )`,
+    values: [itemIds, scenarioName, projectName],
+})
+
 export const saveData = (itemId, data, dataType) => {
     return {
         text: "INSERT INTO jtl.data(item_id, item_data, data_type) VALUES($1, $2, $3)",

--- a/src/server/routes/item.ts
+++ b/src/server/routes/item.ts
@@ -9,6 +9,7 @@ import {
     paramsSchema, updateItemBodySchema,
     newItemParamSchema,
     newAsyncItemStartBodySchema, shareTokenSchema, upsertUserItemChartSettings, stopItemAsyncBodySchema,
+    deleteItemsBodySchema,
 } from "../schema-validator/item-schema"
 import {
     environmentQuerySchema,
@@ -19,6 +20,7 @@ import { getItemsController } from "../controllers/item/get-items-controller"
 import { getItemController } from "../controllers/item/get-item-controller"
 import { updateItemController } from "../controllers/item/update-item-controller"
 import { deleteItemController } from "../controllers/item/delete-item-controller"
+import { deleteItemsController } from "../controllers/item/delete-items-controller"
 import { createItemController } from "../controllers/item/create-item-controller"
 import { getProcessingItemsController } from "../controllers/item/get-processing-items-controller"
 import { createItemAsyncController } from "../controllers/item/create-item-async-controller"
@@ -40,6 +42,14 @@ export class ItemsRoutes {
     routes(app: express.Application): void {
 
         app.route("/api/projects/:projectName/scenarios/:scenarioName/items")
+            .delete(
+                authenticationMiddleware,
+                authorizationMiddleware([AllowedRoles.Operator, AllowedRoles.Admin]),
+                paramsSchemaValidator(newItemParamSchema),
+                bodySchemaValidator(deleteItemsBodySchema),
+                projectExistsMiddleware,
+                wrapAsync(deleteItemsController))
+
             .get(
                 authenticationMiddleware,
                 authorizationMiddleware([AllowedRoles.Readonly, AllowedRoles.Operator, AllowedRoles.Admin]),

--- a/src/server/schema-validator/item-schema.ts
+++ b/src/server/schema-validator/item-schema.ts
@@ -70,6 +70,16 @@ export const upsertUserItemChartSettings = Joi.array().items(Joi.object().keys({
     metric: Joi.string().required(),
 })).required()
 
+export const MAX_DELETE_ITEMS = 100
+
 export const stopItemAsyncBodySchema = Joi.object().keys({
     status,
+})
+
+export const deleteItemsBodySchema = Joi.object({
+  itemIds: Joi.array()
+    .items(Joi.string().uuid())
+    .min(1)
+    .max(MAX_DELETE_ITEMS)
+    .required(),
 })


### PR DESCRIPTION
## Summary
Add `DELETE /api/projects/:projectName/scenarios/:scenarioName/items` endpoint for batch deletion of test run items. Enables multi-select delete from the frontend.
## Changes
- **`src/server/queries/items.ts`** — New `deleteItems()` query using `ANY($1::uuid[])` for atomic batch delete
- **`src/server/controllers/item/delete-items-controller.ts`** — New controller handling batch delete request
- **`src/server/schema-validator/item-schema.ts`** — New `deleteItemsBodySchema` validating array of UUIDs (1–100 items)
- **`src/server/routes/item.ts`** — New `DELETE` route on collection path with auth, validation, and project existence middleware
## Spec
DELETE /api/projects/:projectName/scenarios/:scenarioName/items
Body: { "itemIds": "uuid1", "uuid2", ... }
→ 204 No Content
Single statement with `ANY()` ensures atomicity — no partial deletes. Idempotent by design (non-existent UUIDs return 204).
**Related PR:** https://github.com/ludeknovy/jtl-reporter-fe/pull/444